### PR TITLE
Update MakeFile - Updating alfanous Firefox toolbar build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ dist_sis:
 # Firefox toolbar
 dist_xpi:
 	cd ./interfaces/toolbars/firefox/chrome ; zip -r alfanoustoolbar.jar content/* skin/*
-	cd ./interfaces/toolbars/firefox ; zip alfanous_toolbar_$(VERSION).xpi install.rdf chrome.manifest chrome/alfanoustoolbar.jar
+	cd ./interfaces/toolbars/firefox ; zip alfanous_toolbar_$(VERSION).xpi install.rdf chrome.manifest defaults/* chrome/alfanoustoolbar.jar
 	mkdir output/$(VERSION) ; mv ./interfaces/toolbars/firefox/alfanous_toolbar_$(VERSION).xpi ./output/$(VERSION)
 
 


### PR DESCRIPTION
Adding "defaults/*" to dist_xpi: " Alfanous firefox" of 0.7 version to enable autocomplete search
