### PR TITLE
When switching skins, don't remove the old skin until the new one is ready

### DIFF
--- a/src/alfanous-django/wui/static/shared/js/style_switcher.js
+++ b/src/alfanous-django/wui/static/shared/js/style_switcher.js
@@ -1,5 +1,5 @@
 const COOKIE_SKIN_NAME = 'skin';
-const SKIN_CSS_ID = '#skin_css';
+const SKIN_CSS_ID = 'skin_css';
 
 function change_skin(skin_id,skin_type) {
   var $newCSS = $('<link>', {
@@ -7,10 +7,10 @@ function change_skin(skin_id,skin_type) {
     type: 'text/css',
     href: '/static/ltr/css/skins/bootstrap_' + skin_id + '.css'
   }).on('load', function() {
-    $(SKIN_CSS_ID).remove();
+    $('#' + SKIN_CSS_ID).remove();
     $(this).attr('id', SKIN_CSS_ID);
   });
-  $('head').append($newCSS);
+  $('head').prepend($newCSS);
 
    /*
    logo_type ="dark"; // dark is the default logo type


### PR DESCRIPTION
Currently, when the user switches the skin, the page will stay without any css for a while until the new CSS is loaded. This change will avoid the issue by keeping the old css and switch only when the new css is ready.
