### PR TITLE
Few fixes to make the code work in different environment with Python 2.6

### DIFF
--- a/src/alfanous-django/settings.py
+++ b/src/alfanous-django/settings.py
@@ -155,7 +155,7 @@ TEMPLATE_DIRS = (
   # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
   # Always use forward slashes, even on Windows.
   # Don't forget to use absolute paths, not relative paths.
-  'templates/',
+  os.path.join(ROOT_DIR, 'templates/'),
 )
 
 INSTALLED_APPS = (

--- a/src/alfanous-django/wui/templatetags/query.py
+++ b/src/alfanous-django/wui/templatetags/query.py
@@ -1,5 +1,5 @@
-from collections import OrderedDict
 from django.template import Library
+from django.utils.datastructures import SortedDict
 from wui.templatetags import Params, xget, optional_assignment_tag
 
 Library.optional_assignment_tag = optional_assignment_tag
@@ -40,7 +40,7 @@ def build_query(params, colon_separated_query, separator=' + '):
 @register.optional_assignment_tag(takes_context=True)
 def aya_query(context, result_or_aya):
   fields = xget(context, 'bidi.fields')
-  return build_query(context['params'], OrderedDict([
+  return build_query(context['params'], SortedDict([
     (fields['sura'], quotes(xget(result_or_aya, 'identifier.sura_name', 'sura'))),
     (fields['aya_id'], xget(result_or_aya, 'aya.id', 'aya.aya_id', 'id')),
   ]))
@@ -48,12 +48,12 @@ def aya_query(context, result_or_aya):
 @register.optional_assignment_tag(takes_context=True)
 def ar_aya_query(context, result_content):
   fields = xget(context, 'bidi.fields')
-  return build_query(context['params'], OrderedDict([
+  return build_query(context['params'], SortedDict([
     (fields['sura_arabic'], quotes(xget(result_content, 'identifier.sura_arabic_name'))),
     (fields['aya_id'], xget(result_content, 'aya.id')),
   ]))
 
 @register.optional_assignment_tag(takes_context=True)
 def simple_query(context, separator, **kwargs):
-  query = OrderedDict(kwargs.iteritems())
+  query = SortedDict(kwargs.iteritems())
   return build_query(context['params'], query, separator=separator)


### PR DESCRIPTION
- Use django's SortedDict instead of collections.OrderedDict.
- In settings, make TEMPLATE_DIRS absolute paths.
