### PR TITLE
Araby_Statistics.py refactored

### DIFF
--- a/src/alfanous-labs/PyArabic/Araby_Statistics.py
+++ b/src/alfanous-labs/PyArabic/Araby_Statistics.py
@@ -10,6 +10,13 @@ import re
 
 from araby import araby
 
+__all__ = ['letters', 'diacritics', 'letter_count', 'hamza_count', 'words',
+    'gwords', 'sunletters', 'moonletters']
+
+word_pattern = re.compile( "[^\n\r \t]+" )
+gword_pattern = re.compile( u"لله" )
+GWORDS_FORMS = set( [u"أبالله", u"وتالله", u"بالله", u"تالله", u"والله", u"الله", u"ولله", u"اللهم", u"آلله", u"فلله", u"لله", u"فالله", ] )
+
 araby = araby()
 
 def letters( text ):
@@ -27,13 +34,10 @@ def hamza_count( text ):
 
 
 def words( text ):
-    word_pattern = re.compile( "[^\n\r \t]+" )
     return len( word_pattern.findall( text ) )
 
 def gwords( text ):
     """ Search by regular expression then filter the possibilities """
-    gword_pattern = re.compile( u"لله" )
-    GWORDS_FORMS = set( [u"أبالله", u"وتالله", u"بالله", u"تالله", u"والله", u"الله", u"ولله", u"اللهم", u"آلله", u"فلله", u"لله", u"فالله", ] )
     results = set( gword_pattern.findall( araby.stripTashkeel( text ) ) ) & GWORDS_FORMS
     return len( results )
 


### PR DESCRIPTION
added: __all__ to specify what to be used outside the module plus faster lookup when using 'from Araby_Statistics import *'.

edited: word_pattern, gword_pattern and GWORDS_FORMS moved out of their functions since they has nothing to do with their functions parameters plus better performance, especially for patterns.
