### PR TITLE
Fixed the vocalized query in the title.

### DIFF
--- a/src/alfanous-django/wui/templatetags/meta.py
+++ b/src/alfanous-django/wui/templatetags/meta.py
@@ -4,6 +4,7 @@ from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _
 import re
 from wui.templatetags import xget
+from alfanous.Support.PyArabic.araby_constants import TASHKEEL
 
 register = Library()
 
@@ -13,7 +14,7 @@ TITLE_SUFFIX = {
   'word': _("Quran Word Search"),
 }
 
-TITLE_CLEANER = re.compile('[^\w_]+', re.UNICODE)
+TITLE_CLEANER = re.compile('[^\w%s_]+' % ''.join(TASHKEEL), re.UNICODE)
 
 def query_for_title(query):
   return TITLE_CLEANER.sub(' ', query).encode('UTF-8')

--- a/src/alfanous-django/wui/views.py
+++ b/src/alfanous-django/wui/views.py
@@ -5,7 +5,7 @@
 TODO make a fields English-Arabic mapping based on the "bidi" value to be used in localization
 
 """
-import json
+import json, os
 from operator import itemgetter
 from sys import path
 
@@ -22,7 +22,10 @@ from django.utils.datastructures import SortedDict
 ## either append the path of alfanous API as:
 from wui.templatetags.languages import my_get_language_info
 
-path.insert(0, "../../src") ## a relative path, development mode
+# this is better than using "../../"
+realtive_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+
+path.insert(0, realtive_path) ## a relative path, development mode
 path.append("alfanous.egg/alfanous") ## an egg, portable
 path.append("/home/alfanous/alfanous-django/src/") ## absolute  path, server mode
 


### PR DESCRIPTION
Vocalized queries aren't showing correctly in the title. That was because we were replacing all non-letters with spaces. Now we exclude tashkeel symbols from being replaced.
https://github.com/Alfanous-team/alfanous/issues/402
