### PR TITLE
Fit the PEP-394

### DIFF
--- a/src/PyCorpus/QuranyCorpus.py
+++ b/src/PyCorpus/QuranyCorpus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #coding:utf-8
 
 

--- a/src/PyCorpus/setup.py
+++ b/src/PyCorpus/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding = utf-8
 
 

--- a/src/PyZekrModels/setup.py
+++ b/src/PyZekrModels/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding = utf-8
 
 from setuptools import setup

--- a/src/alfanous-cgi/alfanous_json2.py
+++ b/src/alfanous-cgi/alfanous_json2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: UTF-8 -*- 
 
 ##     Copyright (C) 2009-2012 Assem Chelli <assem.ch [at] gmail.com>

--- a/src/alfanous-cgi/salam.py
+++ b/src/alfanous-cgi/salam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 print "Content-Type: text/html; charset=utf-8\n\n" 
 print 

--- a/src/alfanous-desktop/setup.py
+++ b/src/alfanous-desktop/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 # TODO: package for MacOS

--- a/src/alfanous-django/manage.py
+++ b/src/alfanous-django/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import sys
 

--- a/src/alfanous-django/public/django.fcgi
+++ b/src/alfanous-django/public/django.fcgi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import os, sys
 
 _PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/src/alfanous-import/Downloader.py
+++ b/src/alfanous-import/Downloader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding: utf-8
 
 ##     Copyright (C) 2009-2012 Assem Chelli <assem.ch [at] gmail.com>

--- a/src/alfanous-import/Importer.py
+++ b/src/alfanous-import/Importer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding: utf-8
 
 ##     Copyright (C) 2009-2012 Assem Chelli <assem.ch [at] gmail.com>

--- a/src/alfanous-import/Transformer.py
+++ b/src/alfanous-import/Transformer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding: utf-8
 
 ##     Copyright (C) 2009-2012 Assem Chelli <assem.ch [at] gmail.com>

--- a/src/alfanous-import/Updater.py
+++ b/src/alfanous-import/Updater.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/python2
 # config : utf-8
 
 import json

--- a/src/alfanous-import/initial_importing.py
+++ b/src/alfanous-import/initial_importing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding: utf-8
 
 ##     Copyright (C) 2009-2012 Assem Chelli <assem.ch [at] gmail.com>

--- a/src/alfanous-import/main.py
+++ b/src/alfanous-import/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding: utf-8
 
 ##     Copyright (C) 2009-2012 Assem Chelli <assem.ch [at] gmail.com>

--- a/src/alfanous-import/setup.py
+++ b/src/alfanous-import/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #coding=utf-8
 
 """

--- a/src/alfanous-labs/Qrawler/QuranicCrawler.py
+++ b/src/alfanous-labs/Qrawler/QuranicCrawler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding: utf-8
 '''
 Created on 18 févr. 2010

--- a/src/alfanous-labs/Qrawler/test.py
+++ b/src/alfanous-labs/Qrawler/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 indexingcrawler.py - Demonstrating custom crawler writing by

--- a/src/alfanous/Outputs.py
+++ b/src/alfanous/Outputs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: UTF-8 -*-
 
 ##     Copyright (C) 2009-2012 Assem Chelli <assem.ch [at] gmail.com>

--- a/src/alfanous/QueryProcessing.py
+++ b/src/alfanous/QueryProcessing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding: utf-8
 
 # #     Copyright (C) 2009-2012 Assem Chelli <assem.ch [at] gmail.com>

--- a/src/alfanous/Support/PyArabic/araby.py
+++ b/src/alfanous/Support/PyArabic/araby.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding=utf-8 -*-
 
 # ------------

--- a/src/alfanous/Support/PyArabic/araby_constants.py
+++ b/src/alfanous/Support/PyArabic/araby_constants.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding=utf-8 -*-
 
 import re

--- a/src/alfanous/setup.py
+++ b/src/alfanous/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding = utf-8
 
 """


### PR DESCRIPTION
Change all '#!/usr/bin/python' to '#!/usr/bin/python2' to avoid conflict with OS's with python3 installed by default (like ArchLinux), this fit the PEP-394 standard https://www.python.org/dev/peps/pep-0394/