### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/Alfanous-team/alfanous.png?label=ready&title=Ready 
+ :target: https://waffle.io/Alfanous-team/alfanous
+ :alt: 'Stories in Ready'
    **note** This project needs more contributors and/or funding. If you like it, see `how you can help? <https://github.com/Alfanous-team/alfanous/blob/master/FAQ.rst#how-you-can-help>`_.
 
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/Alfanous-team/alfanous

This was requested by a real person (user assem-ch) on waffle.io, we're not trying to spam you.